### PR TITLE
refactor: 공통 ScreenHeader 컴포넌트 분리

### DIFF
--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -1,43 +1,48 @@
+import styled from '@emotion/native';
 import { Link } from 'expo-router';
-import { StyleSheet, Text, View } from 'react-native';
+import { View } from 'react-native';
+
+import { Text } from '@/shared/ui/Text';
 
 export default function NotFoundScreen() {
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>404</Text>
-      <Text style={styles.subtitle}>페이지를 찾을 수 없습니다.</Text>
-      <Link href="/" style={styles.link}>
-        <Text style={styles.linkText}>홈으로 돌아가기</Text>
-      </Link>
-    </View>
+    <Container>
+      <TitleText>404</TitleText>
+      <SubtitleText>페이지를 찾을 수 없습니다.</SubtitleText>
+      <StyledLink href="/">
+        <LinkText>홈으로 돌아가기</LinkText>
+      </StyledLink>
+    </Container>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#fff',
-    padding: 20,
-  },
-  title: {
-    fontSize: 72,
-    fontWeight: 'bold',
-    color: '#333',
-  },
-  subtitle: {
-    fontSize: 18,
-    color: '#666',
-    marginTop: 10,
-    marginBottom: 30,
-  },
-  link: {
-    marginTop: 15,
-  },
-  linkText: {
-    fontSize: 16,
-    color: '#0066cc',
-    textDecorationLine: 'underline',
-  },
-});
+const Container = styled(View)`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  background-color: ${({ theme }) => theme.colors.primary.white};
+  padding: 20px;
+`;
+
+const TitleText = styled(Text)`
+  font-size: 72px;
+  font-weight: bold;
+  color: ${({ theme }) => theme.colors.primary.black};
+`;
+
+const SubtitleText = styled(Text)`
+  font-size: 18px;
+  color: ${({ theme }) => theme.colors.text.secondary};
+  margin-top: 10px;
+  margin-bottom: 30px;
+`;
+
+const StyledLink = styled(Link)`
+  margin-top: 15px;
+`;
+
+const LinkText = styled(Text)`
+  font-size: 16px;
+  color: ${({ theme }) => theme.colors.primary.main};
+  text-decoration-line: underline;
+`;

--- a/src/features/chat/screens/ChatRoomListScreen.tsx
+++ b/src/features/chat/screens/ChatRoomListScreen.tsx
@@ -8,6 +8,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { ChatRoomList } from '../components/ChatRoomList';
 import { useChatRoomList } from '../hooks/useChatRoomList';
 
+import { ScreenHeader } from '@/shared/ui/ScreenHeader';
 import { Text } from '@/shared/ui/Text';
 
 export function ChatRoomListScreen() {
@@ -24,11 +25,7 @@ export function ChatRoomListScreen() {
     return (
       <SafeArea edges={['top']}>
         <Container>
-          <Header>
-            <Text variant="titleM" weight="bold" color={theme.colors.primary.black}>
-              채팅
-            </Text>
-          </Header>
+          <ScreenHeader title="채팅" />
           <CenteredView>
             <ActivityIndicator size="large" />
           </CenteredView>
@@ -42,11 +39,7 @@ export function ChatRoomListScreen() {
     return (
       <SafeArea edges={['top']}>
         <Container>
-          <Header>
-            <Text variant="titleM" weight="bold" color={theme.colors.primary.black}>
-              채팅
-            </Text>
-          </Header>
+          <ScreenHeader title="채팅" />
           <CenteredView>
             <Text
               variant="m"
@@ -73,11 +66,7 @@ export function ChatRoomListScreen() {
     return (
       <SafeArea edges={['top']}>
         <Container>
-          <Header>
-            <Text variant="titleM" weight="bold" color={theme.colors.primary.black}>
-              채팅
-            </Text>
-          </Header>
+          <ScreenHeader title="채팅" />
           <CenteredView>
             <Text variant="m" weight="medium" color={theme.colors.text.tertiary} align="center">
               참여 중인 채팅방이 없습니다
@@ -92,11 +81,7 @@ export function ChatRoomListScreen() {
   return (
     <SafeArea edges={['top']}>
       <Container>
-        <Header>
-          <Text variant="titleM" weight="bold" color={theme.colors.primary.black}>
-            채팅
-          </Text>
-        </Header>
+        <ScreenHeader title="채팅" />
         <ChatRoomList
           rooms={rooms}
           onRoomPress={handleEnterChat}
@@ -112,16 +97,11 @@ export function ChatRoomListScreen() {
 const SafeArea = styled(SafeAreaView)`
   flex: 1;
   background-color: ${({ theme }) => theme.colors.primary.white};
-  /* Changed background to white to match design (usually list backgrounds are white or light gray) */
 `;
 
 const Container = styled(View)`
   flex: 1;
   gap: 18px;
-`;
-
-const Header = styled(View)`
-  padding: 16px 20px;
 `;
 
 const CenteredView = styled(View)`

--- a/src/features/profile/screens/ProfileScreen.tsx
+++ b/src/features/profile/screens/ProfileScreen.tsx
@@ -1,23 +1,17 @@
 import styled from '@emotion/native';
-import { useTheme } from '@emotion/react';
 import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { ProfileCard } from '../components/ProfileCard';
 import { ProfileMenuList } from '../components/ProfileMenuList';
 
-import { Text } from '@/shared/ui/Text';
+import { ScreenHeader } from '@/shared/ui/ScreenHeader';
 
 export function ProfileScreen() {
-  const theme = useTheme();
   return (
     <SafeArea edges={['top']}>
       <Container>
-        <Header>
-          <Text variant="titleM" weight="semiBold" color={theme.colors.primary.black}>
-            MY
-          </Text>
-        </Header>
+        <ScreenHeader title="MY" />
         <ContentWrapper>
           <ProfileCard />
           <ProfileMenuList />
@@ -39,8 +33,4 @@ const Container = styled(View)`
 
 const ContentWrapper = styled(View)`
   gap: 60px;
-`;
-
-const Header = styled(View)`
-  padding: 16px 20px;
 `;

--- a/src/shared/ui/ScreenHeader.tsx
+++ b/src/shared/ui/ScreenHeader.tsx
@@ -1,0 +1,28 @@
+import styled from '@emotion/native';
+import { useTheme } from '@emotion/react';
+import React from 'react';
+import { View, ViewStyle } from 'react-native';
+
+import { Text } from '@/shared/ui/Text';
+
+interface ScreenHeaderProps {
+  title: string;
+  weight?: 'bold' | 'semiBold' | 'medium' | 'regular';
+  style?: ViewStyle;
+}
+
+export function ScreenHeader({ title, weight = 'semiBold', style }: ScreenHeaderProps) {
+  const theme = useTheme();
+
+  return (
+    <Container style={style}>
+      <Text variant="titleM" weight={weight} color={theme.colors.primary.black}>
+        {title}
+      </Text>
+    </Container>
+  );
+}
+
+const Container = styled(View)`
+  padding: 16px 20px;
+`;


### PR DESCRIPTION
# 🔗 관련 이슈

X

## 📝 작업 내용

- 스크린 컴포넌트에 해당하는 header 영역을 공통 컴포넌트로 분리했습니다.

## 📷 스크린샷 (UI 작업인 경우)

X

## 💬 리뷰어에게

현재 구현된 채팅, 마이페이지 부분의 헤더는 교체를 한 상태입니다.

추후 @Yeram9286 님이 버스 목록 화면을 구현하실 때 ScreenHeader 컴포넌트를 이용해서 헤더 부분을 구현하시면 될 것 같습니다!

## ✅ 기본 체크리스트

- [x] 코드가 정상적으로 실행되나요? (`yarn start` 빌드 에러 없음)
- [x] **(중요) 안드로이드/iOS 시뮬레이터에서 각각 확인했나요?**
- [x] 불필요한 `console.log`나 주석을 제거했나요?
- [x] `yarn format`을 실행하여 코드 스타일을 정렬했나요?
- [x] `yarn lint`를 실행하여 린트 에러가 없나요?

## 🏗️ 구조 체크리스트 (Self-Check)

> 💡 아래 항목을 위반하면 코드 리뷰어에게 반려될 수 있습니다!

### 파일 및 폴더

- [x] **1개 기능 전용 컴포넌트**는 `features/` 안에 두었나요? (❌ `shared/ui` 금지)
- [x] **재사용 컴포넌트**만 `shared/ui`에 두었나요?
- [x] **파일이 3개 이상**일 때만 폴더로 묶었나요? (불필요한 `index.ts` 방지)

### 상태 관리 & 네이밍

- [x] **서버 데이터**는 React Query, **UI 상태**는 Zustand를 사용했나요?
- [x] **Boolean 변수**는 `is`, `has`, `should`로 시작하나요?

---

🚀 **모든 체크리스트를 확인한 후 PR을 생성하세요!**
